### PR TITLE
Register commands in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,24 @@
             "title": "Lime configuration",
             "properties": {
             }
-        }
+        },
+        "commands": [
+            {
+                "title": "Select Target",
+                "command": "lime.selectTarget",
+                "category": "Lime"
+            },
+            {
+                "title": "Select Build Configuration",
+                "command": "lime.selectBuildConfig",
+                "category": "Lime"
+            },
+            {
+                "title": "Edit Target Flags",
+                "command": "lime.editTargetFlags",
+                "category": "Lime"
+            }
+        ]
     },
     "extensionDependencies": [
         "nadako.vshaxe"


### PR DESCRIPTION
This allows for a more keyboard-centered workflow, since it makes the commands reachable from the command palette (right now, you have to pick up the mouse each time to change targets):

![](http://i.imgur.com/oVTpNoZ.png)

Also, this allows setting keyboard shortcuts for the commands.

Commands also show up in the "Contributions" section of the marketplace:

![](http://i.imgur.com/eBcCBW7.png)