### PR TITLE
package.json: use ellipses for command titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,17 +45,17 @@
         },
         "commands": [
             {
-                "title": "Select Target",
+                "title": "Select Target...",
                 "command": "lime.selectTarget",
                 "category": "Lime"
             },
             {
-                "title": "Select Build Configuration",
+                "title": "Select Build Configuration...",
                 "command": "lime.selectBuildConfig",
                 "category": "Lime"
             },
             {
-                "title": "Edit Target Flags",
+                "title": "Edit Target Flags...",
                 "command": "lime.editTargetFlags",
                 "category": "Lime"
             }


### PR DESCRIPTION
This is good practice in UI design to indicate that something asks for input (rather than immediately executing an action). VSCode tends to follow this for their commands, and Vshaxe also does it, but I forget about it for Lime. :)