### PR TITLE
Prefix tooltips of status bar items "Lime:"

### DIFF
--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -82,17 +82,17 @@ class Main {
 	private function construct ():Void {
 		
 		selectTargetItem = window.createStatusBarItem (Left, 19);
-		selectTargetItem.tooltip = "Select Target";
+		selectTargetItem.tooltip = "Lime: Select Target";
 		selectTargetItem.command = "lime.selectTarget";
 		context.subscriptions.push (selectTargetItem);
 		
 		selectBuildConfigItem = window.createStatusBarItem (Left, 18);
-		selectBuildConfigItem.tooltip = "Select Build Configuration";
+		selectBuildConfigItem.tooltip = "Lime: Select Build Configuration";
 		selectBuildConfigItem.command = "lime.selectBuildConfig";
 		context.subscriptions.push (selectBuildConfigItem);
 		
 		editTargetFlagsItem = window.createStatusBarItem (Left, 17);
-		editTargetFlagsItem.tooltip = "Additional Command-Line Arguments";
+		editTargetFlagsItem.tooltip = "Lime: Edit Target Flags";
 		editTargetFlagsItem.command = "lime.editTargetFlags";
 		context.subscriptions.push (editTargetFlagsItem);
 		

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -82,17 +82,17 @@ class Main {
 	private function construct ():Void {
 		
 		selectTargetItem = window.createStatusBarItem (Left, 19);
-		selectTargetItem.tooltip = "Lime: Select Target";
+		selectTargetItem.tooltip = "Lime: Select Target...";
 		selectTargetItem.command = "lime.selectTarget";
 		context.subscriptions.push (selectTargetItem);
 		
 		selectBuildConfigItem = window.createStatusBarItem (Left, 18);
-		selectBuildConfigItem.tooltip = "Lime: Select Build Configuration";
+		selectBuildConfigItem.tooltip = "Lime: Select Build Configuration...";
 		selectBuildConfigItem.command = "lime.selectBuildConfig";
 		context.subscriptions.push (selectBuildConfigItem);
 		
 		editTargetFlagsItem = window.createStatusBarItem (Left, 17);
-		editTargetFlagsItem.tooltip = "Lime: Edit Target Flags";
+		editTargetFlagsItem.tooltip = "Lime: Edit Target Flags...";
 		editTargetFlagsItem.command = "lime.editTargetFlags";
 		context.subscriptions.push (editTargetFlagsItem);
 		


### PR DESCRIPTION
This makes it less likely that the user is confused where they come from.
Also made the editTargetFlagsItem tooltip consistent with the command name.