### PR TITLE
Add a task definition to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,17 @@
                 "command": "lime.editTargetFlags",
                 "category": "Lime"
             }
+        ],
+        "taskDefinitions": [
+            {
+                "type": "lime",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "The Lime command to run"
+                    }
+                }
+            }
         ]
     },
     "extensionDependencies": [

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -160,7 +160,7 @@ class Main {
 	
 	private function createTask (description:String, command:String, ?group:TaskGroup) {
 		
-		var definition:TaskDefinition = cast {
+		var definition:LimeTaskDefinition = {
 			
 			type: "lime",
 			command: command
@@ -600,6 +600,12 @@ class Main {
 	}
 	
 	
+}
+
+
+private typedef LimeTaskDefinition = {
+	>TaskDefinition,
+	var command:String;
 }
 
 


### PR DESCRIPTION
Without this, it's not possible to e.g. mark the "build" command as the default build task - VSCode will mark "lime" as an unkown task type.

![](http://i.imgur.com/rezKtZM.png)