### PR TITLE
Update tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,35 +1,31 @@
-// This file is generated with vshaxe-build - DO NOT EDIT MANUALLY!
 {
-    "suppressTaskName": true,
     "version": "2.0.0",
     "command": "haxe",
+    "suppressTaskName": true,
     "tasks": [
         {
             "args": [
                 "build.hxml",
                 "-debug",
-                "-D", "JSTACK_MAIN=lime.vscode.Main.main",
                 "-D", "js-unflatten"
             ],
             "taskName": "build (debug)",
             "problemMatcher": "$haxe",
-            "isBuildCommand": true
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         },
         {
             "args": [
-                "build.hxml",
+                "build.hxml"
             ],
             "taskName": "build (release)",
             "problemMatcher": "$haxe",
-            "isBuildCommand": true
-        },
-        {
-            "args": [
-                "build.hxml",
-            ],
-            "isTestCommand": true,
-            "taskName": "test",
-            "problemMatcher": "$haxe"
-        },
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        }
     ]
 }


### PR DESCRIPTION
Removed the deprecated isBuildCommand / isTestCommand properties as well as the no longer accurate "file is generated with vshaxe-build" comment.