### PR TITLE
Fix tasks not working in release mode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,8 +6,7 @@
         {
             "args": [
                 "build.hxml",
-                "-debug",
-                "-D", "js-unflatten"
+                "-debug"
             ],
             "taskName": "build (debug)",
             "problemMatcher": "$haxe",

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -389,7 +389,7 @@ class Main {
 	static function main () {}
 	
 	
-	public function provideTasks (?token:CancellationToken):ProviderResult<Array<Task>> {
+	@:access(vscode.TaskGroup) public function provideTasks (?token:CancellationToken):ProviderResult<Array<Task>> {
 		
 		var tasks = [
 			createTask ("Clean", "clean", TaskGroup.Clean),
@@ -397,7 +397,7 @@ class Main {
 			createTask ("Build", "build", TaskGroup.Build),
 			createTask ("Run", "run"),
 			//createTask ("Test", "test", TaskGroup.Test),
-			createTask ("Test", "test", untyped __js__('new vscode.TaskGroup ("test", "Test")')),
+			createTask ("Test", "test", new TaskGroup ("test", "Test")),
 		];
 		
 		var target = getTarget ();


### PR DESCRIPTION
The debug task had -D js-unflatten, and the hack to work around Microsoft/vscode#30207 used a dot-path. Presumably this also means tasks don't work in previous marketplace releases.
As a workaround, I added a private constructor to TaskGroup: vshaxe/vscode-extern@2114a66