### PR TITLE
Update to API changes, revert to ShellExecution

### DIFF
--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -179,7 +179,7 @@ class Main {
 		//var task = new Task (definition, description, "Lime");
 		var args = getCommandArguments (command);
 		var task = new Task (definition, args.join (" "), "lime");
-		task.execution = new ProcessExecution ("lime", args, { cwd: workspace.rootPath, env: haxeEnvironment });
+		task.execution = new ShellExecution ("lime " + args.join (" "), { cwd: workspace.rootPath, env: haxeEnvironment });
 		task.presentationOptions = { panel: TaskPanelKind.Shared, reveal: /*TaskRevealKind.Silent*/ TaskRevealKind.Always };
 		
 		if (group != null) {

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -367,17 +367,10 @@ class Main {
 	
 		}
 
-		var haxePath = haxeConfiguration.path;
-		if (!Path.isAbsolute (haxePath)) {
-			
-			haxePath = Path.join ([workspace.rootPath, haxePath]);
-		
-		}
-
-		if (FileSystem.exists (haxePath)) {
+		if (!haxeConfiguration.isCommand) {
 
 			var separator = Sys.systemName () == "Windows" ? ";" : ":";
-			env["PATH"] = Path.directory (haxePath) + separator + Sys.getEnv("PATH");
+			env["PATH"] = Path.directory (haxeConfiguration.executable) + separator + Sys.getEnv("PATH");
 
 		}
 		

--- a/src/vshaxe/HaxeExecutableConfiguration.hx
+++ b/src/vshaxe/HaxeExecutableConfiguration.hx
@@ -5,10 +5,15 @@ package vshaxe;
 **/
 typedef HaxeExecutableConfiguration = {
     /**
-        Path to the Haxe executable. Can be a relative or absolute path,
-        or just a command / alias like `"haxe"`.
+        Absolute path to the Haxe executable, or a command / alias like `"haxe"`.
+        Use `isCommand` to check.
     **/
-    var path(default,never):String;
+    var executable(default,never):String;
+
+    /**
+        Whether `executable` is a command (`true`) or an absolute path (`false`).
+    **/
+    var isCommand(default,never):Bool;
 
     /**
         Additional environment variables used for running Haxe executable.


### PR DESCRIPTION
I had to revert to using ShellExecution, otherwise I wouldn't even have been able to test the API changes.