### PR TITLE
Remove redundant part of the description

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "nadako.vshaxe": "^1.8.0"
     },
     "displayName": "Lime",
-    "description": "Adds support for Lime and OpenFL projects in Visual Studio Code",
+    "description": "Adds support for Lime and OpenFL projects",
     "categories": [
         "Other"
     ],


### PR DESCRIPTION
The description is usually viewed from the VSCode Marketplace or from within VSCode, so it's obvious that the extension is for VSCode.