### PR TITLE
Mark "command" in Lime task definition as required

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "taskDefinitions": [
             {
                 "type": "lime",
+                "required": ["command"],
                 "properties": {
                     "command": {
                         "type": "string",


### PR DESCRIPTION
Not sure if it makes a big difference, but it's definitely more correct.