### PR TITLE
Add support for --connect, closes #26

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "publisher": "openfl",
     "engines": {
         "vscode": "^1.14.0",
-        "nadako.vshaxe": "^1.9.0"
+        "nadako.vshaxe": "^1.10.0"
     },
     "displayName": "Lime",
     "description": "Lime and OpenFL project support",

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -179,7 +179,17 @@ class Main {
 		
 		//var task = new Task (definition, description, "Lime");
 		var args = getCommandArguments (command);
-		var task = new Task (definition, args.join (" "), "lime");
+		var name = args.join (" ");
+		
+		var displayPort = getVshaxe ().displayPort;
+		if (getVshaxe ().enableCompilationServer && displayPort != null) {
+
+			args.push('--haxeflag="--connect $displayPort"');
+
+		}
+
+		var task = new Task (definition, name, "lime");
+		
 		task.execution = new ShellExecution ("lime " + args.join (" "), { cwd: workspace.rootPath, env: haxeEnvironment });
 		task.presentationOptions = { panel: TaskPanelKind.Shared, reveal: /*TaskRevealKind.Silent*/ TaskRevealKind.Always };
 		

--- a/src/vshaxe/Vshaxe.hx
+++ b/src/vshaxe/Vshaxe.hx
@@ -20,6 +20,20 @@ typedef Vshaxe = {
     var haxeExecutable(default,never):HaxeExecutable;
 
     /**
+        The port at which the completion server is reachable via `--connect`, or `null`.
+        Corresponds to the `"haxe.displayPort"` setting.
+
+        Should be respected by generated tasks that call Haxe directly or indirectly if `enableCompilationServer` is `true`.
+    **/
+    @:optional var displayPort(default,never):Int;
+
+    /**
+        Whether the `displayPort` should be used to connect to the compilation server for building.
+        Corresponds to the `"haxe.enableCompilationServer"` setting.
+    **/
+    var enableCompilationServer(default,never):Bool;
+
+    /**
         Register a display argument provider.
 
         Display arguments are passed to the Haxe Language Server for completion and used for the dependency explorer.


### PR DESCRIPTION
This adds support for building through the compilation server. Requires the upcoming vshaxe version (1.10.0).
This makes a pretty drastic difference in terms of compilation performance - building a Flixel project for Neko takes ~5 seconds normally, but only 1-2s with a cache built-up (no file changes).