### PR TITLE
Add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+### 1.1.0 (to be released)
+
+**New Features**:
+
+- added `"lime.defaultBuildConfiguration"` and `"lime.defaultTarget"` settings ([#27](https://github.com/openfl/lime-vscode-extension/issues/27))
+- added support for building through the compilation server ([#28](https://github.com/openfl/lime-vscode-extension/issues/28))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lime-vscode-extension",
-    "version": "1.0.8",
+    "version": "1.1.0",
     "publisher": "openfl",
     "engines": {
         "vscode": "^1.14.0",


### PR DESCRIPTION
Added a changelog, similar to the one vshaxe has:

https://github.com/vshaxe/vshaxe/blob/master/CHANGELOG.md

I think it's a good idea to have one, especially since VSCode has nice builtin support for it:

![](https://i.imgur.com/FqLCSgv.png)

I upped the next version to a minor release (1.1.0) because it adds new features. The release date will still have to be filled in (note that vshaxe 1.10.0 has to be released first).