### PR TITLE
Remove unused @:access()

### DIFF
--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -445,7 +445,7 @@ class Main {
 	static function main () {}
 	
 	
-	@:access(vscode.TaskGroup) public function provideTasks (?token:CancellationToken):ProviderResult<Array<Task>> {
+	public function provideTasks (?token:CancellationToken):ProviderResult<Array<Task>> {
 		
 		var tasks = [
 			createTask ("Clean", "clean", TaskGroup.Clean),


### PR DESCRIPTION
Forgot to remove this along with the `TaskGroup` constructor call in #31.