### PR TITLE
Add a lime.command setting + better error reporting, closes #11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Added support for the `haxe.taskPresentation` setting in vshaxe 1.11.0 ([#31](https://github.com/openfl/lime-vscode-extension/issues/31))
 * Added support for the new problem matchers in vshaxe 1.11.0 ([#31](https://github.com/openfl/lime-vscode-extension/issues/31))
+* Added `lime.command` for using a custom Lime command ([#35](https://github.com/openfl/lime-vscode-extension/issues/35))
 
 1.1.0 (04/04/2018)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 * Added support for the `haxe.taskPresentation` setting in vshaxe 1.11.0 ([#31](https://github.com/openfl/lime-vscode-extension/issues/31))
 * Added support for the new problem matchers in vshaxe 1.11.0 ([#31](https://github.com/openfl/lime-vscode-extension/issues/31))
-* Added `lime.command` for using a custom Lime command ([#35](https://github.com/openfl/lime-vscode-extension/issues/35))
+* Added `lime.command` for using a custom Lime command ([#36](https://github.com/openfl/lime-vscode-extension/issues/36))
+* Added an error message in case the `lime display` command fails ([#36](https://github.com/openfl/lime-vscode-extension/issues/36))
 
 1.1.0 (04/04/2018)
 ------------------

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
                         "Debug",
                         "Final"
                     ]
+                },
+                "lime.command": {
+                    "description": "The Lime command to call in tasks and for `lime display`",
+                    "type": "string",
+                    "default": "lime"
                 }
             }
         },

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -191,7 +191,7 @@ class Main {
 		
 		var task = new Task (definition, name, "lime");
 		
-		task.execution = new ShellExecution ("lime " + args.join (" "), { cwd: workspace.rootPath, env: haxeEnvironment });
+		task.execution = new ShellExecution ("lime " + args.join (" "), { cwd: workspace.workspaceFolders[0].uri.fsPath, env: haxeEnvironment });
 		
 		if (group != null) {
 			
@@ -554,10 +554,6 @@ class Main {
 		
 		if (!hasProjectFile || !isProviderActive) return;
 		
-		var projectFile = getProjectFile ();
-		var buildConfigFlags = getBuildConfigFlags ();
-		var targetFlags = getTargetFlags ();
-		
 		var commandLine = "lime " + getCommandArguments ("display").join (" ");
 		commandLine = StringTools.replace (commandLine, "-verbose", "");
 		
@@ -565,7 +561,7 @@ class Main {
 		
 		try {
 			
-			ChildProcess.exec (commandLine, { cwd: workspace.rootPath }, function (err, stdout:Buffer, stderror) {
+			ChildProcess.exec (commandLine, { cwd: workspace.workspaceFolders[0].uri.fsPath }, function (err, stdout:Buffer, stderror) {
 				
 				try {
 					

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -575,9 +575,14 @@ class Main {
 			if (err != null && err.code != 0) {
 	
 				var message = 'Lime completion setup failed. Is the lime command available? Try running "lime setup" or changing the "lime.command" setting.';
-				window.showErrorMessage (message, "Show Full Error").then (function (_) {
+				var showFullErrorLabel = "Show Full Error";
+				window.showErrorMessage (message, showFullErrorLabel).then (function (selection) {
 
-					commands.executeCommand ("workbench.action.toggleDevTools");
+					if (selection == showFullErrorLabel) {
+
+						commands.executeCommand ("workbench.action.toggleDevTools");
+
+					}
 
 				});
 				trace (err);

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -561,32 +561,26 @@ class Main {
 		
 		var commandLine = getCommand () + " " + getCommandArguments ("display").join (" ");
 		commandLine = StringTools.replace (commandLine, "-verbose", "");
-		
-		//trace ("Running display command: " + commandLine);
-		
-		try {
+
+		ChildProcess.exec (commandLine, { cwd: workspace.workspaceFolders[0].uri.fsPath }, function (err, stdout:Buffer, stderror) {
 			
-			ChildProcess.exec (commandLine, { cwd: workspace.workspaceFolders[0].uri.fsPath }, function (err, stdout:Buffer, stderror) {
-				
-				try {
-					
-					displayArgumentsProvider.update (stdout.toString ());
-					
-				} catch (e:Dynamic) {
-					
-					trace ("Error running display command: " + commandLine);
-					trace (e);
-					
-				}
-				
-			});
-			
-		} catch (e:Dynamic) {
-			
-			trace ("Error running display command: " + commandLine);
-			trace (e);
-			
-		}
+			if (err != null && err.code != 0) {
+	
+				var message = 'Lime completion setup failed. Is the lime command available? Try running "lime setup" or changing the "lime.command" setting.';
+				window.showErrorMessage (message, "Show Full Error").then (function (_) {
+
+					commands.executeCommand ("workbench.action.toggleDevTools");
+
+				});
+				trace (err);
+
+			} else {
+
+				displayArgumentsProvider.update (stdout.toString ());
+
+			}
+
+		});
 		
 	}
 	

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -191,7 +191,7 @@ class Main {
 		
 		var task = new Task (definition, name, "lime");
 		
-		task.execution = new ShellExecution ("lime " + args.join (" "), { cwd: workspace.workspaceFolders[0].uri.fsPath, env: haxeEnvironment });
+		task.execution = new ShellExecution (getCommand () + " " + args.join (" "), { cwd: workspace.workspaceFolders[0].uri.fsPath, env: haxeEnvironment });
 		
 		if (group != null) {
 			
@@ -228,6 +228,14 @@ class Main {
 		
 	}
 	
+
+	private function getCommand ():String {
+
+		var command = workspace.getConfiguration ("lime").get ("command");
+		return if (command == null) "lime" else command;
+	
+	}
+
 	
 	private function getCommandArguments (command:String):Array<String> {
 		
@@ -516,9 +524,6 @@ class Main {
 	
 	public function resolveTask (task:Task, ?token:CancellationToken):ProviderResult<Task> {
 		
-		//var definition:LimeTaskDefinition = cast task.definition;
-		//var command = definition.command;
-		//task.execution = new ProcessExecution ("lime", getCommandArguments (command), { cwd: workspace.rootPath });
 		return task;
 		
 	}
@@ -554,7 +559,7 @@ class Main {
 		
 		if (!hasProjectFile || !isProviderActive) return;
 		
-		var commandLine = "lime " + getCommandArguments ("display").join (" ");
+		var commandLine = getCommand () + " " + getCommandArguments ("display").join (" ");
 		commandLine = StringTools.replace (commandLine, "-verbose", "");
 		
 		//trace ("Running display command: " + commandLine);


### PR DESCRIPTION
This is the error that's now shown in the lower right if `lime.display` fails:

![](https://i.imgur.com/P0h57Lb.png)