### PR TITLE
Rename lime.command to lime.executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 * Added support for the `haxe.taskPresentation` setting in vshaxe 1.11.0 ([#31](https://github.com/openfl/lime-vscode-extension/issues/31))
 * Added support for the new problem matchers in vshaxe 1.11.0 ([#31](https://github.com/openfl/lime-vscode-extension/issues/31))
-* Added `lime.command` for using a custom Lime command ([#36](https://github.com/openfl/lime-vscode-extension/issues/36))
+* Added `lime.executable` for using a custom Lime command ([#36](https://github.com/openfl/lime-vscode-extension/issues/36))
 * Added an error message in case the `lime display` command fails ([#36](https://github.com/openfl/lime-vscode-extension/issues/36))
 
 1.1.0 (04/04/2018)

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
                         "Final"
                     ]
                 },
-                "lime.command": {
-                    "description": "The Lime command to call in tasks and for `lime display`",
+                "lime.executable": {
+                    "description": "The Lime executable to call in tasks and for `lime display`. Can be multiple arguments separated by spaces or a path to an executable.",
                     "type": "string",
                     "default": "lime"
                 }

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -47,35 +47,31 @@ class Main {
 		
 		hasProjectFile = false;
 		
-		try {
+		if (getProjectFile () != "") {
 			
-			if (getProjectFile () != "") {
-				
-				hasProjectFile = true;
-				
-			}
+			hasProjectFile = true;
 			
-			if (!hasProjectFile) {
-				
-				// TODO: multi-folder support
+		}
+		
+		if (!hasProjectFile) {
+			
+			// TODO: multi-folder support
 
-				var wsFolder = if (workspace.workspaceFolders == null) null else workspace.workspaceFolders[0];
-				var rootPath = wsFolder.uri.fsPath;
+			var wsFolder = if (workspace.workspaceFolders == null) null else workspace.workspaceFolders[0];
+			var rootPath = wsFolder.uri.fsPath;
+			
+			if (rootPath != null) {
 				
-				if (rootPath != null) {
+				// TODO: support custom project file references
+				
+				var files = [ "project.xml", "Project.xml", "project.hxp", "project.lime" ];
+				
+				for (file in files) {
 					
-					// TODO: support custom project file references
-					
-					var files = [ "project.xml", "Project.xml", "project.hxp", "project.lime" ];
-					
-					for (file in files) {
+					if (FileSystem.exists (rootPath + "/" + file)) {
 						
-						if (FileSystem.exists (rootPath + "/" + file)) {
-							
-							hasProjectFile = true;
-							break;
-							
-						}
+						hasProjectFile = true;
+						break;
 						
 					}
 					

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -232,7 +232,18 @@ class Main {
 	private function getExecutable ():String {
 
 		var executable = workspace.getConfiguration ("lime").get ("executable");
-		return if (executable == null) "lime" else executable;
+		if (executable == null) {
+		
+			executable = "lime";
+		
+		}
+		// naive check to see if it's a path, or multiple arguments such as "haxelib run lime"
+		if (FileSystem.exists(executable)) {
+
+			executable = '"' + executable + '"';
+
+		}
+		return executable;
 	
 	}
 

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -30,7 +30,7 @@ class Main {
 	private var selectTargetItem:StatusBarItem;
 	private var targetItems:Array<TargetItem>;
 	private var haxeEnvironment:DynamicAccess<String>;
-	private var limeCommand:String;
+	private var limeExecutable:String;
 	
 	
 	public function new (context:ExtensionContext) {
@@ -195,7 +195,7 @@ class Main {
 		
 		var task = new Task (definition, name, "lime");
 		
-		task.execution = new ShellExecution (limeCommand + " " + args.join (" "), { cwd: workspace.workspaceFolders[0].uri.fsPath, env: haxeEnvironment });
+		task.execution = new ShellExecution (limeExecutable + " " + args.join (" "), { cwd: workspace.workspaceFolders[0].uri.fsPath, env: haxeEnvironment });
 		
 		if (group != null) {
 			
@@ -233,10 +233,10 @@ class Main {
 	}
 	
 
-	private function getCommand ():String {
+	private function getExecutable ():String {
 
-		var command = workspace.getConfiguration ("lime").get ("command");
-		return if (command == null) "lime" else command;
+		var executable = workspace.getConfiguration ("lime").get ("executable");
+		return if (executable == null) "lime" else executable;
 	
 	}
 
@@ -496,11 +496,11 @@ class Main {
 				
 			}
 			
-			var oldLimeCommand = limeCommand;
-			limeCommand = getCommand ();
-			var limeCommandChanged = oldLimeCommand != limeCommand;
+			var oldLimeExecutable = limeExecutable;
+			limeExecutable = getExecutable ();
+			var limeExecutableChanged = oldLimeExecutable != limeExecutable;
 
-			if (isProviderActive && (!initialized || limeCommandChanged)) {
+			if (isProviderActive && (!initialized || limeExecutableChanged)) {
 				
 				if (!initialized) {
 					
@@ -567,14 +567,14 @@ class Main {
 		
 		if (!hasProjectFile || !isProviderActive) return;
 		
-		var commandLine = limeCommand + " " + getCommandArguments ("display").join (" ");
+		var commandLine = limeExecutable + " " + getCommandArguments ("display").join (" ");
 		commandLine = StringTools.replace (commandLine, "-verbose", "");
 
 		ChildProcess.exec (commandLine, { cwd: workspace.workspaceFolders[0].uri.fsPath }, function (err, stdout:Buffer, stderror) {
 			
 			if (err != null && err.code != 0) {
 	
-				var message = 'Lime completion setup failed. Is the lime command available? Try running "lime setup" or changing the "lime.command" setting.';
+				var message = 'Lime completion setup failed. Is the lime command available? Try running "lime setup" or changing the "lime.executable" setting.';
 				var showFullErrorLabel = "Show Full Error";
 				window.showErrorMessage (message, showFullErrorLabel).then (function (selection) {
 


### PR DESCRIPTION
(for consistency with `haxe.executable`)

I also noticed that we weren't quoting it when it's a path, with would break it if it contains spaces or commas (such as `C:/HaxeToolkit/haxe/lib/lime/6,2,0/templates/bin/lime.exe`). 