### PR TITLE
Require the same vscode version as vshaxe does

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.2.0",
     "publisher": "openfl",
     "engines": {
-        "vscode": "^1.14.0",
+        "vscode": "^1.20.0",
         "nadako.vshaxe": "^1.11.0"
     },
     "displayName": "Lime",


### PR DESCRIPTION
Otherwise, Lime might auto-update itself into an incompatible configuration (see http://community.openfl.org/t/visual-studio-code-build-commands-disappeared/10398/10).
closes #41