### PR TITLE
Remove "configuration" from the settings title

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     ],
     "contributes": {
         "configuration": {
-            "title": "Lime configuration",
+            "title": "Lime",
             "properties": {
                 "lime.projectFile": {
                     "description": "Custom path to Lime project file",


### PR DESCRIPTION
VSCode 1.25 introduces a table of contents in the new experimental settings editor (https://code.visualstudio.com/updates/v1_25#_new-settings-editor), which uses this title. Quite a few extension have "configuration" at the end there, but it arguably seems a bit redundant:

![](https://i.imgur.com/0ABhM2y.png)