### PR TITLE
Add support for showReuseMessage in haxe.taskPresentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+1.2.2 (??/??/2018)
+------------------
+
+* Updated the minimum required VSCode version to 1.25.0
+* Added support for `showReuseMessage` in `haxe.taskPresentation` ([#46](https://github.com/openfl/lime-vscode-extension/issues/46))
+
 1.2.1 (03/05/2018)
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "version": "1.2.1",
     "publisher": "openfl",
     "engines": {
-        "vscode": "^1.20.0",
-        "nadako.vshaxe": "^1.11.0"
+        "vscode": "^1.25.0",
+        "nadako.vshaxe": "^2.1.0"
     },
     "displayName": "Lime",
     "description": "Lime and OpenFL project support",

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -106,7 +106,7 @@ class Main {
 		disposables.push (commands.registerCommand ("lime.selectBuildConfig", selectBuildConfigItem_onCommand));
 		disposables.push (commands.registerCommand ("lime.editTargetFlags", editTargetFlagsItem_onCommand));
 		
-		disposables.push (workspace.registerTaskProvider ("lime", this));
+		disposables.push (tasks.registerTaskProvider ("lime", this));
 		
 	}
 	
@@ -205,7 +205,8 @@ class Main {
 			reveal: presentation.reveal,
 			echo: presentation.echo,
 			focus: presentation.focus,
-			panel: presentation.panel
+			panel: presentation.panel,
+			showReuseMessage: presentation.showReuseMessage
 		};
 		return task;
 		


### PR DESCRIPTION
VSCode 1.25.0 added showReuseMessage as a task presentation option, and vshaxe added support for it in its API in 2.1.0 that was just released.