### PR TITLE
Only set preLaunchTask if not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+1.3.1 (to be released)
+------------------
+* Improved the `"lime"` debug adapter to not set `"preLaunchTask"` if already specified
+
 1.3.0 (04/01/2019)
 ------------------
 

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -589,7 +589,10 @@ class Main
 				trace(e);
 			}
 
-			config.preLaunchTask = "lime: build (active configuration)";
+			if (!Reflect.hasField(config, "preLaunchTask"))
+			{
+				config.preLaunchTask = "lime: build (active configuration)";
+			}
 
 			switch (target)
 			{


### PR DESCRIPTION
This allows having a launch configuration that debugs the last build right away without re-building with `"preLaunchTask": null`, among other things.