### PR TITLE
Avoid warnings for non-built-in targets in targetConfigurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,18 +112,25 @@
 							"target": {
 								"type": "string",
 								"description": "A supported Lime target.",
-								"enum": [
-									"android",
-									"air",
-									"flash",
-									"neko",
-									"hl",
-									"html5",
-									"windows",
-									"mac",
-									"linux",
-									"emscripten",
-									"electron"
+								"anyOf": [
+									{
+										"enum": [
+											"android",
+											"air",
+											"flash",
+											"neko",
+											"hl",
+											"html5",
+											"windows",
+											"mac",
+											"linux",
+											"emscripten",
+											"electron"
+										]
+									},
+									{
+										"type": "string"
+									}
 								]
 							},
 							"args": {


### PR DESCRIPTION
Basically, this still gives code completion for the built-in targets, but doesn't show a warning for custom ones anymore.