### PR TITLE
build.hxml: updated cp and lib for vshaxe repo reorganization

### DIFF
--- a/build.hxml
+++ b/build.hxml
@@ -1,9 +1,9 @@
--cp node_modules/vshaxe/vscode-extern/src
--cp node_modules/vshaxe/src-api
+-cp node_modules/vshaxe/haxelib/src
 -cp src
 -D hxnodejs-no-version-warning
 -D analyzer-optimize
 -lib hxnodejs
+-lib vscode
 -js bin/lime-vscode.js
 -dce full
 -main lime.extension.Main


### PR DESCRIPTION
It looks like some things moved around in the vshaxe repo. I had to tweak build.hxml to get lime-vscode-extension to compile.