### PR TITLE
HTML5 Debug: when launching the lime debug configuration, if the lime test task is already running, use lime build for the preLaunchTask instead

### DIFF
--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -646,7 +646,24 @@ class Main
 					config.sourceMaps = true;
 					config.smartStep = true;
 					config.webRoot = "${workspaceFolder}/" + Path.directory(outputFile);
-					config.preLaunchTask = "lime: " + getCommandArguments("test", targetItem) + " -nolaunch";
+
+					// search for an existing "lime test" task
+					var testTaskName = getCommandArguments("test", targetItem) + " -nolaunch";
+					var existingTask = Vscode.tasks.taskExecutions.get().find((item) ->
+						{
+							return item.task.definition.type == "lime" && item.task.name == testTaskName;
+						});
+					if (existingTask == null)
+					{
+						// if the "test" task doesn't exist yet, run it first
+						config.preLaunchTask = "lime: " + testTaskName;
+					}
+					else
+					{
+						// if the "test" task is already active, run the "build" task instead
+						// this will reuse the existing server
+						config.preLaunchTask = "lime: " + getCommandArguments("build", targetItem);
+					}
 
 				case "windows", "mac", "linux":
 					config.type = "hxcpp";


### PR DESCRIPTION
If I launch the "lime" debug configuration, it automatically runs the "lime: test html5 -debug -nolaunch" task. This command builds the project, starts a server, and opens Chrome.

Example *launch.json*:

```jsonc
{
	// Use IntelliSense to learn about possible attributes.
	// Hover to view descriptions of existing attributes.
	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
	"version": "0.2.0",
	"configurations": [
		{
			"name": "Lime",
			"type": "lime",
			"request": "launch"
		}
	]
}
```

When I close Chrome, the debugger disconnects. However, the server keeps running.

Later, if I've make some changes to my code, and I tell VSCode to start debugging again, the "lime: test html5 -debug -nolaunch" is already running. In that case, VSCode skips the task and just opens a browser. Nothing gets built, so my changes to the code are not reflected in what is loaded in the browser.

Since running "lime test" builds the project before launching a server, I think that, for consistency, the extension should run "lime build" if "lime test" is already active.