### PR TITLE
Add support for HashLink debugging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.insertSpaces": false,
     "files.trimTrailingWhitespace": false,
-    "haxe.displayConfigurations": [
+    "haxe.configurations": [
         ["build.hxml"]
     ],
     "haxe.diagnosticsPathFilter": "${workspaceRoot}/(?!syntaxes/cases)",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
 	"version": "1.3.2",
 	"publisher": "openfl",
 	"engines": {
-		"vscode": "^1.31.0",
-		"nadako.vshaxe": "^2.5.0"
+		"vscode": "^1.42.0",
+		"nadako.vshaxe": "^2.19.1"
 	},
 	"displayName": "Lime",
 	"description": "Lime and OpenFL project support",

--- a/src/lime/extension/DisplayArgsProvider.hx
+++ b/src/lime/extension/DisplayArgsProvider.hx
@@ -3,11 +3,12 @@ package lime.extension;
 class DisplayArgsProvider
 {
 	public var description(default, never):String = "Project using Lime/OpenFL command-line tools";
+	public var parsedArguments(default, null):Array<String>;
 
 	private var activationChangedCallback:Bool->Void;
 	private var api:Vshaxe;
 	private var arguments:String;
-	private var parsedArguments:Array<String>;
+
 	private var updateArgumentsCallback:Array<String>->Void;
 
 	public function new(api:Vshaxe, activationChangedCallback:Bool->Void)

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -517,10 +517,6 @@ class Main
 
 	private function registerDebugConfigurationProviders():Void
 	{
-		debug.registerDebugConfigurationProvider("chrome", this);
-		debug.registerDebugConfigurationProvider("fdb", this);
-		debug.registerDebugConfigurationProvider("hl", this);
-		debug.registerDebugConfigurationProvider("hxcpp", this);
 		debug.registerDebugConfigurationProvider("lime", this);
 	}
 


### PR DESCRIPTION
This requires a new release of hashlink-debugger to work (https://github.com/vshaxe/hashlink-debugger/pull/73).

I've only tested this on Windows, but it should theoretically works on Linux too. HashLink debugging on Mac is not supported yet - I've copied the same error message that hashlink-debugger uses for this so the user gets some feedback (it appears that VSCode only calls `resolveDebugConfiguration()` once, even though hl-debugger has its own `resolveDebugConfiguration()` too / there's no "chaining").