### PR TITLE
Detect project file changes, closes #12

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,11 @@
 				"title": "Select Target Configuration",
 				"command": "lime.selectTarget",
 				"category": "Lime"
+			},
+			{
+				"title": "Refresh Code Completion",
+				"command": "lime.refreshCodeCompletion",
+				"category": "Lime"
 			}
 		],
 		"debuggers": [

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -87,6 +87,7 @@ class Main
 
 		disposables.push(commands.registerCommand("lime.selectTarget", selectTargetItem_onCommand));
 		disposables.push(commands.registerCommand("lime.editTargetFlags", editTargetFlagsItem_onCommand));
+		disposables.push(commands.registerCommand("lime.refreshCodeCompletion", refreshCodeCompletion));
 		disposables.push(tasks.registerTaskProvider("lime", this));
 	}
 
@@ -412,12 +413,17 @@ class Main
 		{
 			if (choice == "Yes")
 			{
-				var commandLine = limeExecutable + " " + getCommandArguments("update", getTargetItem());
-				ChildProcess.execSync(commandLine, {cwd: workspace.workspaceFolders[0].uri.fsPath});
-				updateDisplayArguments();
+				refreshCodeCompletion();
 			}
 		});
 		isProjectFileDirty = false;
+	}
+
+	private function refreshCodeCompletion()
+	{
+		var commandLine = limeExecutable + " " + getCommandArguments("update", getTargetItem());
+		ChildProcess.execSync(commandLine, {cwd: workspace.workspaceFolders[0].uri.fsPath});
+		updateDisplayArguments();
 	}
 
 	@:keep @:expose("activate") public static function activate(context:ExtensionContext)


### PR DESCRIPTION
This feels like a huge improvement for the user experience. :)

![](https://i.imgur.com/9jH4AdO.gif)

I also added a command to do this manually via the command palette in case the changes come from somewhere external we can't detect (`haxelib update` or similar).