### PR TITLE
Fix display argument provider being disposed on deactivation

### DIFF
--- a/src/lime/extension/DisplayArgsProvider.hx
+++ b/src/lime/extension/DisplayArgsProvider.hx
@@ -21,9 +21,9 @@ class DisplayArgsProvider
 	{
 		updateArgumentsCallback = provideArguments;
 
-		if (arguments != null)
+		if (parsedArguments != null)
 		{
-			update(arguments);
+			updateArguments();
 		}
 
 		activationChangedCallback(true);

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -21,6 +21,7 @@ class Main
 
 	private var context:ExtensionContext;
 	private var displayArgumentsProvider:DisplayArgsProvider;
+	private var displayArgumentsProviderDisposable:Disposable;
 	private var disposables:Array<{function dispose():Void;}> = [];
 	private var editTargetFlagsItem:StatusBarItem;
 	private var hasProjectFile:Bool;
@@ -101,7 +102,6 @@ class Main
 
 		selectTargetItem = null;
 		editTargetFlagsItem = null;
-		displayArgumentsProvider = null;
 		isProjectFileDirty = false;
 
 		disposables = [];
@@ -124,7 +124,7 @@ class Main
 		}
 		else
 		{
-			disposables.push(api.registerDisplayArgumentsProvider("Lime", displayArgumentsProvider));
+			displayArgumentsProviderDisposable = api.registerDisplayArgumentsProvider("Lime", displayArgumentsProvider);
 		}
 	}
 
@@ -576,6 +576,13 @@ class Main
 			deconstruct();
 		}
 
+		if (!hasProjectFile && displayArgumentsProviderDisposable != null)
+		{
+			displayArgumentsProviderDisposable.dispose();
+			displayArgumentsProviderDisposable = null;
+			displayArgumentsProvider = null;
+		}
+
 		if (initialized)
 		{
 			updateTargetItems();
@@ -709,9 +716,9 @@ class Main
 					// search for an existing "lime test" task
 					var testTaskName = getCommandArguments("test", targetItem) + " -nolaunch";
 					var existingTask = Vscode.tasks.taskExecutions.copy().find((item) ->
-						{
-							return item.task.definition.type == "lime" && item.task.name == testTaskName;
-						});
+					{
+						return item.task.definition.type == "lime" && item.task.name == testTaskName;
+					});
 					if (existingTask == null)
 					{
 						// if the "test" task doesn't exist yet, run it first


### PR DESCRIPTION
When selecting another completion provider like Haxe ("deactivation"), Lime would vanish from the list because it would invoke the disposable. Now that should only happen when there is no project file.