### PR TITLE
Falls back to `haxelib run lime` when lime alias is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,6 +243,9 @@
 			}
 		]
 	},
+	"dependencies": {
+		"hasbin": "^1.2.3"
+	},
 	"devDependencies": {
 		"haxe": "^5.2.1"
 	},

--- a/src/Hasbin.hx
+++ b/src/Hasbin.hx
@@ -1,0 +1,6 @@
+@:jsRequire("hasbin")
+@:native("hasbin")
+extern class Hasbin
+{
+	public static function sync(binaryName:String):Bool;
+}

--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -222,6 +222,10 @@ class Main
 		{
 			executable = '"' + executable + '"';
 		}
+		if (executable == "lime" && !Hasbin.sync(executable))
+		{
+			executable = "haxelib run lime";
+		}
 		return executable;
 	}
 


### PR DESCRIPTION
With this change, the extension will continue to prefer the lime alias, when it exists. However, if the alias doesn't exist, the extension will fall back to using `haxelib run lime` instead.

One less thing to set up manually is a very good thing for people trying out Lime/OpenFL for the first time.