### PR TITLE
If Lime is not installed, offer to install it from Haxelib. If Lime is installed, but the alias is missing, add the alias automatically.

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,6 +243,9 @@
 			}
 		]
 	},
+	"dependencies": {
+		"hasbin": "^1.2.3"
+	},
 	"devDependencies": {
 		"haxe": "^5.2.1"
 	},

--- a/src/Hasbin.hx
+++ b/src/Hasbin.hx
@@ -1,0 +1,6 @@
+@:jsRequire("hasbin")
+@:native("hasbin")
+extern class Hasbin
+{
+	public static function sync(binaryName:String):Bool;
+}


### PR DESCRIPTION
Makes first-time setup much easier!