### PR TITLE
Account for target flags when generating HXML

### DIFF
--- a/src/lime/extension/Main.hx
+++ b/src/lime/extension/Main.hx
@@ -1135,6 +1135,7 @@ class Main
 			else
 			{
 				var hxml = stdout.toString();
+				hxml += getTargetFlags().split(" ").join("\n");
 				var projectDirectory = getProjectDirectory();
 				if (projectDirectory != "")
 				{


### PR DESCRIPTION
When the extension generates the HXML via the `lime display` command, it doesn't account for the additional target flags the user might have specified. Because of this, they'd appear as undefined when looking through the code:

<img width="394" height="231" alt="Screenshot 2026-03-22 131226" src="https://github.com/user-attachments/assets/011766c3-1b32-4993-89c6-ed5d26b956b8" />

To fix it, I simply append the flags to the HXML before it's sent over to Haxe.

<img width="284" height="191" alt="Screenshot 2026-03-22 131319" src="https://github.com/user-attachments/assets/34f7b331-5d93-447f-b6dd-2e5bd84e8ca3" />
